### PR TITLE
Fixed broken CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: python -m tox
 
   package:
-    name: Build & publish package
+    name: Test package build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - bug_122_broken_ci
     tags:
       - v*.*.*
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - bug_122_broken_ci
     tags:
       - v*.*.*
   pull_request:

--- a/pymavswarm/connection.py
+++ b/pymavswarm/connection.py
@@ -25,7 +25,7 @@ from pymavswarm.utils import init_logger
 
 
 class Connection:
-    """Handle interaction with the network and the MAVLink connection."""
+    """Handle interaction with the network and the MAVLink connection. this is a test to make sure pipeline fails"""
 
     def __init__(
         self,

--- a/pymavswarm/connection.py
+++ b/pymavswarm/connection.py
@@ -25,7 +25,7 @@ from pymavswarm.utils import init_logger
 
 
 class Connection:
-    """Handle interaction with the network and the MAVLink connection. this is a test to make sure pipeline fails"""
+    """Handle interaction with the network and the MAVLink connection."""
 
     def __init__(
         self,

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ envlist =
 
 [gh-actions]
 python =
-    3.10: py310
+    3.10: py310, lint
 
 [testenv]
 deps = coverage


### PR DESCRIPTION
# Checklist

- [x] I have performed a thorough review of my code
- [x] I have sufficiently commented my code
- [x] The implementation follows the project style conventions
- [x] All project unit tests are passing
- [x] If necessary, documentation has been provided or updated to discuss the changes
- [x] System integration tests are performed successfully
- [x] Any new dependencies have been added to the requirements list
- [x] Any changes that will not be completed or bugs that have been introduced have been added as issues

## Changes Made

This PR resolves an error in which the CI pipeline was not checking for linting errors. This was allowing developers to contribute changes that did not pass the project linters.

## Associated Issues

- Closes #122 

## Files Changed

- `tox.ini`: Added `lint` environment to github actions test environment
- `.github/workflows/ci.yml`: Renamed package testing environment to be less ambiguous

## Testing

Pipeline tests were performed using Github Actions to ensure that a broken change will result in an error in the Github Actions CI pipeline. The test can be observed [here](https://github.com/unl-nimbus-lab/pymavswarm/actions/runs/2989463985).

## Issues Introduced

N/A